### PR TITLE
sbrmi: correct the mailbox errno sign

### DIFF
--- a/sbrmi-common.c
+++ b/sbrmi-common.c
@@ -530,7 +530,7 @@ int rmi_mailbox_xfer(struct apml_sbrmi_device *rmi_dev,
 	u8 byte = 0;
 
 	if (!rmi_dev->regmap)
-		return ENODEV;
+		return -ENODEV;
 
 	msg->fw_ret_code = 0;
 


### PR DESCRIPTION
Normally, the error code is '-' sign, to do check by "ret < 0".